### PR TITLE
correspond for v0.4.0

### DIFF
--- a/gokc.rb
+++ b/gokc.rb
@@ -4,7 +4,7 @@ class Gokc < Formula
   version gokc_version
 
   url "https://github.com/yuuki/gokc/releases/download/v#{gokc_version}/gokc_darwin_amd64.zip"
-  sha256 'd9272381eae14b3b113dcbea77918be3e978fcbf4a7cf28b4642edbba5d46244'
+  sha256 'b0c8ebbed2d1d52f3dd2965bc4fef8d9083b1378aacd4f3961bcee4fadd519d6'
 
   head do
     url 'https://github.com/yuuki/gokc.git'


### PR DESCRIPTION
- for https://github.com/yuuki/homebrew-gokc/issues/2 

## testing

```
[bash] do-su-0805@MBP2018-i7:~ $ brew install do-su-0805/gokc/gokc
==> Installing gokc from do-su-0805/gokc
==> Downloading https://github.com/yuuki/gokc/releases/download/v0.4.0/gokc_darwin_amd64.zip
Already downloaded: /Users/do-su-0805/Library/Caches/Homebrew/downloads/1531615b1bb208aff66f56913cc1bdb228e2dac80c6c40975c3231de49d7a774--gokc_darwin_amd64.zip
�  /usr/local/Cellar/gokc/0.4.0: 5 files, 2.7MB, built in 3 seconds
[bash] do-su-0805@MBP2018-i7:~ $ gokc -v
gokc version 0.4.0
```
