### PR TITLE
correspond for v0.4.1

### DIFF
--- a/gokc.rb
+++ b/gokc.rb
@@ -4,7 +4,7 @@ class Gokc < Formula
   version gokc_version
 
   url "https://github.com/yuuki/gokc/releases/download/v#{gokc_version}/gokc_darwin_amd64.zip"
-  sha256 'd9272381eae14b3b113dcbea77918be3e978fcbf4a7cf28b4642edbba5d46244'
+  sha256 'b0c8ebbed2d1d52f3dd2965bc4fef8d9083b1378aacd4f3961bcee4fadd519d6'
 
   head do
     url 'https://github.com/yuuki/gokc.git'

--- a/gokc.rb
+++ b/gokc.rb
@@ -1,10 +1,10 @@
 class Gokc < Formula
-  gokc_version = '0.4.0'
+  gokc_version = '0.4.1'
   homepage 'https://github.com/yuuki/gokc'
   version gokc_version
 
   url "https://github.com/yuuki/gokc/releases/download/v#{gokc_version}/gokc_darwin_amd64.zip"
-  sha256 'b0c8ebbed2d1d52f3dd2965bc4fef8d9083b1378aacd4f3961bcee4fadd519d6'
+  sha256 'a1e6217bdd0a07ff8ae2c06e00fccd6b0e9078fb6fa1c369aae5c753c5cda276'
 
   head do
     url 'https://github.com/yuuki/gokc.git'

--- a/gokc.rb
+++ b/gokc.rb
@@ -4,7 +4,7 @@ class Gokc < Formula
   version gokc_version
 
   url "https://github.com/yuuki/gokc/releases/download/v#{gokc_version}/gokc_darwin_amd64.zip"
-  sha256 'a1e6217bdd0a07ff8ae2c06e00fccd6b0e9078fb6fa1c369aae5c753c5cda276'
+  sha256 '682635d9a582367151024714f87b7c098638e7248b01d64b93c1a75b3a9228e5'
 
   head do
     url 'https://github.com/yuuki/gokc.git'


### PR DESCRIPTION
- for https://github.com/yuuki/homebrew-gokc/issues/2 

## testing 
```
[g][bash] do-su-0805@MBP2018-i7:homebrew-gokc (fix/change_version_v0.4.1) $ brew install do-su-0805/gokc/gokc
Updating Homebrew...
==> Auto-updated Homebrew!
Updated 1 tap (do-su-0805/gokc).
No changes to formulae.

==> Installing gokc from do-su-0805/gokc
==> Downloading https://github.com/yuuki/gokc/releases/download/v0.4.1/gokc_darwin_amd64.zip
Already downloaded: /Users/do-su-0805/Library/Caches/Homebrew/downloads/76b9fc5b9290a783871b561fce621f8d3582a6d973517635af57e4ec1d1ce6a3--gokc_darwin_amd64.zip
�  /usr/local/Cellar/gokc/0.4.1: 5 files, 2.7MB, built in 3 seconds
Removing: /Users/do-su-0805/Library/Caches/Homebrew/gokc--0.4.0.zip... (994.7KB)
[g][bash] do-su-0805@MBP2018-i7:homebrew-gokc (fix/change_version_v0.4.1) $ gokc -v
gokc version 0.4.1
```